### PR TITLE
Allow metric hooks to be sent in via config

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -41,6 +41,20 @@ func (c *tagCache) get(name tag.Key, value string) tag.Mutator {
 	return t
 }
 
+type KinesisHooker interface {
+	OnDrain(bytes, length int64)
+	OnPutRecords(batches, spanlists, bytes, putLatencyMS int64, reason string)
+	OnPutErr(errCode string)
+	OnDropped(batches, spanlists, bytes int64)
+	OnSpanEnqueued()
+	OnSpanDequeued()
+	OnXLSpanDropped(size int)
+	OnPutSpanListFlushed(spans, bytes int64)
+	OnCompressed(original, compressed int64)
+}
+
+var _ KinesisHooker = &kinesisHooks{}
+
 type kinesisHooks struct {
 	exporterName string
 	streamName   string

--- a/shardProducer.go
+++ b/shardProducer.go
@@ -28,7 +28,7 @@ type shardProducer struct {
 
 	pr            *producer.Producer
 	shard         *Shard
-	hooks         *kinesisHooks
+	hooks         KinesisHooker
 	maxSize       uint64
 	flushInterval time.Duration
 	partitionKey  string


### PR DESCRIPTION
 - if they're not sent in, the existing behavior is maintained