### PR TITLE
Performance improvement in determining a producer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jaegertracing/jaeger v1.8.2
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/signalfx/omnition-kinesis-producer v0.5.0
+	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.19.1
 	go.uber.org/zap v1.9.1
 	golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 // indirect

--- a/hooks.go
+++ b/hooks.go
@@ -41,6 +41,7 @@ func (c *tagCache) get(name tag.Key, value string) tag.Mutator {
 	return t
 }
 
+// KinesisHooker interface abstracts away the hook so one can pass in a producer and inject your own implementation
 type KinesisHooker interface {
 	OnDrain(bytes, length int64)
 	OnPutRecords(batches, spanlists, bytes, putLatencyMS int64, reason string)
@@ -58,7 +59,6 @@ var _ KinesisHooker = &kinesisHooks{}
 type kinesisHooks struct {
 	exporterName string
 	streamName   string
-	shardID      string
 	commonTags   []tag.Mutator
 	tagCache     tagCache
 }

--- a/kinesis.go
+++ b/kinesis.go
@@ -37,6 +37,7 @@ const defaultEncoding = "jaeger-proto"
 
 var supportedEncodings = [1]string{defaultEncoding}
 
+// HookProducer should be a factory for generating KinesisHooker's so you can do your metricization in your own way
 type HookProducer func(name, streamName, shardID string) KinesisHooker
 
 // Options are the options to be used when initializing a Jaeger exporter.
@@ -70,7 +71,7 @@ type Options struct {
 	Encoding string
 }
 
-func (o Options) isValidEncoding() bool {
+func (o *Options) isValidEncoding() bool {
 	for _, e := range supportedEncodings {
 		if e == o.Encoding {
 			return true
@@ -81,8 +82,62 @@ func (o Options) isValidEncoding() bool {
 
 // NewExporter returns a trace.Exporter implementation that exports
 // the collected spans to Jaeger.
-func NewExporter(o Options, logger *zap.Logger) (*Exporter, error) {
+func NewExporter(o *Options, logger *zap.Logger) (*Exporter, error) {
 
+	exporter, err2 := doBasicConfigSanity(o)
+	if err2 != nil {
+		return exporter, err2
+	}
+
+	if o.HookProducer == nil {
+		o.HookProducer = func(name, streamName, shardID string) KinesisHooker {
+			return newKinesisHooks(name, streamName, shardID)
+		}
+	}
+
+	sess := session.Must(session.NewSession(aws.NewConfig().WithRegion(o.AWSRegion)))
+	var cfgs []*aws.Config
+	if o.AWSRole != "" {
+		cfgs = append(cfgs, &aws.Config{Credentials: stscreds.NewCredentials(sess, o.AWSRole)})
+	}
+	if o.AWSKinesisEndpoint != "" {
+		cfgs = append(cfgs, &aws.Config{Endpoint: aws.String(o.AWSKinesisEndpoint)})
+	}
+	client := kinesis.New(sess, cfgs...)
+
+	shardInfo, err := getShardInfo(client, o.StreamName)
+	if err != nil {
+		return nil, err
+	}
+
+	producers := getShardProducer(shardInfo, o, client)
+
+	e := &Exporter{
+		shardInfo: shardInfo,
+		options:   o,
+		producers: producers,
+		logger:    logger,
+		hooks:     o.HookProducer(o.Name, o.StreamName, ""),
+		semaphore: nil,
+	}
+
+	maxReceivers, _ := strconv.Atoi(os.Getenv("MAX_KINESIS_RECEIVERS"))
+	if maxReceivers > 0 {
+		e.semaphore = make(chan struct{}, maxReceivers)
+	}
+
+	if err := registerMetricViews(); err != nil {
+		return nil, err
+	}
+
+	for _, sp := range e.producers {
+		sp.start()
+	}
+
+	return e, nil
+}
+
+func doBasicConfigSanity(o *Options) (*Exporter, error) {
 	if o.MaxListSize == 0 {
 		o.MaxListSize = 100000
 	}
@@ -116,34 +171,16 @@ func NewExporter(o Options, logger *zap.Logger) (*Exporter, error) {
 	if !o.isValidEncoding() {
 		return nil, fmt.Errorf("invalid option for Encoding. Valid choices are: %v", supportedEncodings)
 	}
+	return nil, nil
+}
 
-	if o.HookProducer == nil {
-		o.HookProducer = func(name, streamName, shardID string) KinesisHooker {
-			return newKinesisHooks(name, streamName, shardID)
-		}
-	}
-
-	sess := session.Must(session.NewSession(aws.NewConfig().WithRegion(o.AWSRegion)))
-	var cfgs []*aws.Config
-	if o.AWSRole != "" {
-		cfgs = append(cfgs, &aws.Config{Credentials: stscreds.NewCredentials(sess, o.AWSRole)})
-	}
-	if o.AWSKinesisEndpoint != "" {
-		cfgs = append(cfgs, &aws.Config{Endpoint: aws.String(o.AWSKinesisEndpoint)})
-	}
-	client := kinesis.New(sess, cfgs...)
-
-	shardInfo, err := getShardInfo(client, o.StreamName)
-	if err != nil {
-		return nil, err
-	}
-
+func getShardProducer(shardInfo *ShardInfo, o *Options, client *kinesis.Kinesis) []*shardProducer {
 	producers := make([]*shardProducer, 0, len(shardInfo.shards))
 	for _, shard := range shardInfo.shards {
-		hooks := o.HookProducer(o.Name, o.StreamName, shard.shardId)
+		hooks := o.HookProducer(o.Name, o.StreamName, shard.shardID)
 		pr := producer.New(&producer.Config{
 			OnReshard:           o.OnReshard,
-			Shard:               shard.shardId,
+			Shard:               shard.shardID,
 			StreamName:          o.StreamName,
 			AggregateBatchSize:  o.KPLAggregateBatchSize,
 			AggregateBatchCount: o.KPLAggregateBatchCount,
@@ -164,30 +201,7 @@ func NewExporter(o Options, logger *zap.Logger) (*Exporter, error) {
 			flushInterval: time.Duration(o.ListFlushInterval) * time.Second,
 		})
 	}
-
-	e := &Exporter{
-		shardInfo: shardInfo,
-		options:   &o,
-		producers: producers,
-		logger:    logger,
-		hooks:     o.HookProducer(o.Name, o.StreamName, ""),
-		semaphore: nil,
-	}
-
-	maxReceivers, _ := strconv.Atoi(os.Getenv("MAX_KINESIS_RECEIVERS"))
-	if maxReceivers > 0 {
-		e.semaphore = make(chan struct{}, maxReceivers)
-	}
-
-	if err := registerMetricViews(); err != nil {
-		return nil, err
-	}
-
-	for _, sp := range e.producers {
-		sp.start()
-	}
-
-	return e, nil
+	return producers
 }
 
 // Exporter takes spans in jaeger proto format and forwards them to a kinesis stream

--- a/kinesis_test.go
+++ b/kinesis_test.go
@@ -14,7 +14,7 @@ var exp *Exporter
 var spans []*model.Span
 
 func setup() error {
-	options := Options{
+	options := &Options{
 		Name:               "test",
 		StreamName:         "in_dev_test_tenant",
 		AWSKinesisEndpoint: "http://0.0.0.0:4567",

--- a/shardProducer.go
+++ b/shardProducer.go
@@ -27,11 +27,9 @@ type shardProducer struct {
 	sync.RWMutex
 
 	pr            *producer.Producer
-	shard         *Shard
 	hooks         KinesisHooker
 	maxSize       uint64
 	flushInterval time.Duration
-	partitionKey  string
 
 	gzipWriter *gzip.Writer
 	spans      *model.SpanList

--- a/shardProducer.go
+++ b/shardProducer.go
@@ -18,7 +18,6 @@ import (
 	model "github.com/signalfx/opencensus-go-exporter-kinesis/models/gen"
 )
 
-const magicByteSize = 8
 const avgBatchSize = 1000
 
 var compressedMagicByte = [8]byte{111, 109, 58, 106, 115, 112, 108, 122}

--- a/shards.go
+++ b/shards.go
@@ -34,12 +34,9 @@ func (s *ShardInfo) getIndex(traceID string) (int, error) {
 		return int(rshift.Int64()), nil
 	}
 	// honestly this should be a tree, but it would have to be a custom one so probably not worth the effort since nearly everyone is a power of 2
-	for i, s := range s.shards {
-		ok, err := s.belongsToShardKey(key)
-		if err != nil {
-			return -1, err
-		}
-		if ok {
+	for i := 0; i < len(s.shards); i++ {
+		sh := s.shards[i]
+		if key.Cmp(sh.endingHashKey) <= 0 {
 			return i, nil
 		}
 	}

--- a/shards.go
+++ b/shards.go
@@ -3,6 +3,7 @@ package kinesis
 import (
 	"crypto/md5"
 	"fmt"
+	"math"
 	"math/big"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,14 +16,81 @@ type Shard struct {
 	endingHashKey   *big.Int
 }
 
+type ShardInfo struct {
+	shiftLen uint    // number of bits to shift to get to an int
+	shards   []Shard // use for names and backup if not a power of 2
+	power    bool    // to know if its a power of 2
+}
+
+func (s *ShardInfo) getIndex(traceID string) (int, error) {
+	if len(s.shards) == 1 {
+		return 0, nil
+	}
+	key := partitionKeyToHashKey(traceID)
+	if s.power {
+		rshift := (&big.Int{}).Rsh(key, s.shiftLen)
+		return int(rshift.Int64()), nil
+	}
+	// honestly this should be a tree, but it would have to be a custom one so probably not worth the effort since nearly everyone is a power of 2
+	for i, s := range s.shards {
+		ok, err := s.belongsToShardKey(key)
+		if err != nil {
+			return -1, err
+		}
+		if ok {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("no shard found for parition key %s", traceID)
+}
+
+func getShardInfo(k *kinesis.Kinesis, streamName string) (*ShardInfo, error) {
+	listShardsInput := &kinesis.ListShardsInput{
+		StreamName: aws.String(streamName),
+		MaxResults: aws.Int64(100),
+	}
+	ret := &ShardInfo{}
+
+	for {
+		resp, err := k.ListShards(listShardsInput)
+		if err != nil {
+			return nil, fmt.Errorf("ListShards error: %v", err)
+		}
+
+		for _, s := range resp.Shards {
+			// shard is closed so skip it
+			if s.SequenceNumberRange.EndingSequenceNumber != nil {
+				continue
+			}
+			s := Shard{
+				shardId:         *s.ShardId,
+				startingHashKey: toBigInt(*s.HashKeyRange.StartingHashKey),
+				endingHashKey:   toBigInt(*s.HashKeyRange.EndingHashKey),
+			}
+			ret.shards = append(ret.shards, s)
+			ret.shiftLen = uint(128 - math.Log2(float64(len(ret.shards))))
+			ret.power = math.Ceil(math.Log2(float64(len(ret.shards)))) == math.Floor(math.Log2(float64(len(ret.shards))))
+		}
+
+		if resp.NextToken == nil {
+			//ret.computeBytes()
+			return ret, nil
+		}
+
+		listShardsInput = &kinesis.ListShardsInput{
+			NextToken: resp.NextToken,
+		}
+	}
+}
+
 func getShards(k *kinesis.Kinesis, streamName string) ([]*Shard, error) {
 
 	listShardsInput := &kinesis.ListShardsInput{
 		StreamName: aws.String(streamName),
 		MaxResults: aws.Int64(100),
 	}
+	var shards []*Shard
 
-	shards := []*Shard{}
 	for {
 		resp, err := k.ListShards(listShardsInput)
 		if err != nil {
@@ -57,12 +125,11 @@ func toBigInt(key string) *big.Int {
 	return num
 }
 
-func (s *Shard) belongsToShard(partitionKey string) (bool, error) {
-	key := s.partitionKeyToHashKey(partitionKey)
+func (s *Shard) belongsToShardKey(key *big.Int) (bool, error) {
 	return key.Cmp(s.startingHashKey) >= 0 && key.Cmp(s.endingHashKey) <= 0, nil
 }
 
-func (s *Shard) partitionKeyToHashKey(partitionKey string) *big.Int {
+func partitionKeyToHashKey(partitionKey string) *big.Int {
 	b := md5.Sum([]byte(partitionKey))
 	return big.NewInt(0).SetBytes(b[:])
 }

--- a/shards_test.go
+++ b/shards_test.go
@@ -1,0 +1,129 @@
+package kinesis
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+var xs = [][3]string{
+	{"0", "21267647932558653966460912964485513215", "shardId-000000000000"},
+	{"21267647932558653966460912964485513216", "42535295865117307932921825928971026431", "shardId-000000000001"},
+	{"42535295865117307932921825928971026432", "63802943797675961899382738893456539647", "shardId-000000000002"},
+	{"63802943797675961899382738893456539648", "85070591730234615865843651857942052863", "shardId-000000000003"},
+	{"85070591730234615865843651857942052864", "106338239662793269832304564822427566079", "shardId-000000000004"},
+	{"106338239662793269832304564822427566080", "127605887595351923798765477786913079295", "shardId-000000000005"},
+	{"127605887595351923798765477786913079296", "148873535527910577765226390751398592511", "shardId-000000000006"},
+	{"148873535527910577765226390751398592512", "170141183460469231731687303715884105727", "shardId-000000000007"},
+	{"170141183460469231731687303715884105728", "191408831393027885698148216680369618943", "shardId-000000000008"},
+	{"191408831393027885698148216680369618944", "212676479325586539664609129644855132159", "shardId-000000000009"},
+	{"212676479325586539664609129644855132160", "233944127258145193631070042609340645375", "shardId-000000000010"},
+	{"233944127258145193631070042609340645376", "255211775190703847597530955573826158591", "shardId-000000000011"},
+	{"255211775190703847597530955573826158592", "276479423123262501563991868538311671807", "shardId-000000000012"},
+	{"276479423123262501563991868538311671808", "297747071055821155530452781502797185023", "shardId-000000000013"},
+	{"297747071055821155530452781502797185024", "319014718988379809496913694467282698239", "shardId-000000000014"},
+	{"319014718988379809496913694467282698240", "340282366920938463463374607431768211455", "shardId-000000000015"},
+}
+
+func BenchmarkOGShards(b *testing.B) {
+	partitionKey := "bd7a977555f6b982bd7a977555f6b982"
+	shards := generateV1(xs)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		v, err := getShardProducerIndex(shards, partitionKey)
+		if err != nil || v != 13 {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkNewAShards(b *testing.B) {
+	partitionKey := "bd7a977555f6b982bd7a977555f6b982"
+	shards := generateV2(xs)
+	var v int
+	b.ResetTimer()
+	b.ReportAllocs()
+	var err error
+	for i := 0; i < b.N; i++ {
+		v, err = shards.getIndex(partitionKey)
+		if v != 13 || err != nil {
+			b.Fatal("not 13")
+		}
+	}
+}
+
+func BenchmarkNewAShardsNoPower(b *testing.B) {
+	partitionKey := "bd7a977555f6b982bd7a977555f6b982"
+	shards := generateV2(xs[1:])
+	var v int
+	b.ResetTimer()
+	b.ReportAllocs()
+	var err error
+	for i := 0; i < b.N; i++ {
+		v, err = shards.getIndex(partitionKey)
+		if v != 12 || err != nil {
+			b.Fatal("not 12")
+		}
+	}
+}
+
+func generateV1(xs [][3]string) []*Shard {
+	var shards []*Shard
+	for _, x := range xs {
+		s := &Shard{
+			shardId:         x[2],
+			startingHashKey: toBigInt(x[0]),
+			endingHashKey:   toBigInt(x[1]),
+		}
+		shards = append(shards, s)
+	}
+	return shards
+}
+
+func generateV2(xs [][3]string) *ShardInfo {
+	ret := &ShardInfo{}
+	for _, x := range xs {
+		s := Shard{
+			shardId:         x[2],
+			startingHashKey: toBigInt(x[0]),
+			endingHashKey:   toBigInt(x[1]),
+		}
+		ret.shards = append(ret.shards, s)
+	}
+	ret.shiftLen = uint(128 - math.Log2(float64(len(ret.shards))))
+	ret.power = math.Ceil(math.Log2(float64(len(ret.shards)))) == math.Floor(math.Log2(float64(len(ret.shards))))
+
+	return ret
+}
+
+func getShardProducerIndex(ss []*Shard, traceID string) (int, error) {
+	for i, s := range ss {
+		key := partitionKeyToHashKey(traceID)
+		ok, err := s.belongsToShardKey(key)
+		if err != nil {
+			return -1, err
+		}
+		if ok {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("no shard found for parition key %s", traceID)
+}
+
+func TestSpeed(t *testing.T) {
+
+	//xs := []string{
+	//	"85070591730234615865843651857942052863",
+	//	"170141183460469231731687303715884105727",
+	//	"255211775190703847597530955573826158591",
+	//	"340282366920938463463374607431768211455",
+	//}
+	info := generateV2(xs)
+
+	shards := generateV1(xs)
+	for _, x := range []string{"bd7a977555f6b982", "0000000000000000bd7a977555f6b982", "bd7a977555f6b982bd7a977555f6b982", "0"} {
+		index, _ := getShardProducerIndex(shards, x)
+		index2, _ := info.getIndex(x)
+		fmt.Println(index, index2)
+	}
+}

--- a/shards_test.go
+++ b/shards_test.go
@@ -36,7 +36,7 @@ var xs4 = [][3]string{
 
 const benchTestTraceID = "bd7a977555f6b982bd7a977555f6b982"
 
-func BenchmarkOGShards(b *testing.B) {
+func BenchmarkV1Shards(b *testing.B) {
 	shards := generateV1(xs16)
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -47,7 +47,7 @@ func BenchmarkOGShards(b *testing.B) {
 		}
 	}
 }
-func BenchmarkNewAShards(b *testing.B) {
+func BenchmarkV2Shards(b *testing.B) {
 	shards := generateV2(xs16)
 	var v int
 	b.ResetTimer()
@@ -61,7 +61,7 @@ func BenchmarkNewAShards(b *testing.B) {
 	}
 }
 
-func BenchmarkNewAShardsNoPower(b *testing.B) {
+func BenchmarkV2ShardsNoPower(b *testing.B) {
 	shards := generateV2(xs16[1:])
 	var v int
 	b.ResetTimer()
@@ -124,6 +124,7 @@ func TestEquality(t *testing.T) {
 		test [][3]string
 	}{
 		{name: "16 vnodes", test: xs16},
+		{name: "15 vnodes", test: xs16[1:]},
 		{name: "4 vnodes", test: xs4},
 	}
 	for _, test := range tests {

--- a/telemetry.go
+++ b/telemetry.go
@@ -63,7 +63,7 @@ var (
 	statDrainBytes  = stats.Int64("kinesis_drain_bytes", "size (bytes) of batches when drained from queue", stats.UnitBytes)
 	statDrainLength = stats.Int64("kinesis_drain_length", "number of batches drained from queue", stats.UnitDimensionless)
 
-	statCompressFactor = stats.Int64("kinesis_compress_factor", "compression factor acheived by spanlists", stats.UnitDimensionless)
+	statCompressFactor = stats.Int64("kinesis_compress_factor", "compression factor achieved by spanlists", stats.UnitDimensionless)
 )
 
 // TODO: support telemetry level
@@ -237,7 +237,7 @@ func metricViews() []*view.View {
 	compressFactorView := &view.View{
 		Name:        statCompressFactor.Name(),
 		Measure:     statCompressFactor,
-		Description: "compression factor acheived per spanlist",
+		Description: "compression factor achieved per spanlist",
 		TagKeys:     tagKeys,
 		Aggregation: view.LastValue(),
 	}

--- a/tracegen_test.go
+++ b/tracegen_test.go
@@ -7,18 +7,12 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 )
 
-const (
-	fakeIP uint32 = 1<<24 | 2<<16 | 3<<8 | 4
-
-	fakeSpanDuration = 123 * time.Microsecond
-)
-
 func generateSpans() []*model.Span {
 	spans := []*model.Span{}
 	for i := 0; i <= 1000; i++ {
 		spans = append(spans, &model.Span{
 			SpanID:  model.SpanID(gf.Int64()),
-			TraceID: model.TraceID{gf.Uint64(), gf.Uint64()},
+			TraceID: model.TraceID{Low: gf.Uint64(), High: gf.Uint64()},
 			// StartTime: gf.Date(),
 			Duration:      time.Duration(gf.Second()),
 			OperationName: gf.Word(),


### PR DESCRIPTION
So we were iterating through a slice of pointers (one cache miss) to producers
then referencing a pointer to a shard (another cache miss) then generating the
*big.Int key (for each shard) and doing two comparisons (which do allocations)
This is the OGShards below

New strategy uses the fact that we normally have a power of 2 shards, like all of them in us1.
When getting the shards we can know this, then we know we can just shift the correct
number of bits so that we can just index the slice.
NewShards

In the case it's not a power of 2, we're slightly better than OG, we at least don't create
a new key for each partition.
NewShardsNoPower

BenchmarkOGShards-12             	  355597	      4157 ns/op	    1351 B/op	      31 allocs/op
BenchmarkNewAShards-12           	 3972441	       280 ns/op	      99 B/op	       3 allocs/op
BenchmarkNewAShardsNoPower-12    	  352802	      2989 ns/op	    1040 B/op	      26 allocs/op